### PR TITLE
Fix too early exit in init_datadir for mariadb

### DIFF
--- a/product/ma/local/init_datadir.sh.m4
+++ b/product/ma/local/init_datadir.sh.m4
@@ -3,4 +3,4 @@ set -e
 
 eatmydata=$(which eatmydata 2>/dev/null) || :
 
-$eatmydata mysql_install_db --no-defaults --data=__datadir --log-error=__workdir/.install | head -n 3
+$eatmydata mysql_install_db --no-defaults --data=__datadir --log-error=__workdir/.install | head -n 10


### PR DESCRIPTION
It looks in some scenarios grep may force close mysql_install_db before it finishes initialization